### PR TITLE
main: add websocket support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ env_logger = { version = "0.11", default-features = false, features = ["color", 
 argh = "0.1"
 # not using full regex as it adds more bloat and our requirements are minimal
 regex-lite = "0.1"
+tungstenite = { version = "0.28", features = ["native-tls"] }
+rustix = { version = "1.0", features = ["event"] }
 
 [dev-dependencies]
 tempfile = "3.10"
@@ -22,5 +24,5 @@ reqwest = { version = "0.12", default-features = false, features = ["json"] }
 test-with = { version = "0.14", default-features = false, features = ["runtime"] }
 scopeguard = "1.2"
 gethostname = "1.1.0"
-tokio-tungstenite = "0.28"
-futures-util = { version = "0.3", default-features = false, features = ["sink"] }
+tokio-tungstenite = { version = "0.28" }
+futures-util = { version = "0.3" }

--- a/README.md
+++ b/README.md
@@ -144,8 +144,13 @@ $ printf '{"method":"io.systemd.UserDatabase.GetUserRecord", "parameters": {"ser
       "gid": 0,
 ...
 
+# varlinkctl is supported via our varlinkctl-helper
+$ VARLINK_BRIDGE_URL=http://localhost:8080/ws/sockets/io.systemd.Multiplexer \
+    varlinkctl call --more /usr/libexec/varlinkctl-helper \
+	io.systemd.UserDatabase.GetUserRecord '{"service":"io.systemd.Multiplexer"}'
+
+
 # libvarlink bridge mode gives full varlink CLI support over the network
-# TODO: extend varlinkctl to support something similar (exec:cmd is a bit too limited right now)
 $ varlink --bridge "websocat --binary ws://localhost:8080/ws/sockets/io.systemd.Hostname" info
 Vendor: The systemd Project
 Product: systemd (systemd-hostnamed)

--- a/justfile
+++ b/justfile
@@ -1,22 +1,38 @@
-binary := "target/release/varlink-http-bridge"
-# max_size_kb is a bit arbitrary but it should ensure we don't increase size too much
-# without noticing (currently at 3.2MB)
-max_size := "4 * 1024 * 1024"
-
-check: check_binary_size
+check: check_srv_binary_size check_helper_binary_size
 	cargo fmt --check
 	cargo clippy -- -W clippy::pedantic
 
 test:
 	cargo test
 
+# the httpd service
+srv_binary := "target/release/varlink-http-bridge"
+# max_size_kb is a bit arbitrary but it should ensure we don't increase size too much
+# without noticing (currently at 3.2MB)
+srv_max_size := "4 * 1024 * 1024"
+
+# the varlinkctl helper binary so that varlinkctl exec:varlinkctl-helper can talk to http
+helper_binary := "target/release/varlinkctl-helper"
+helper_max_size := "2 * 1024 * 1024"
+
 [script]
-check_binary_size:
+check_srv_binary_size:
 	cargo build --release
-	max_size_kb="$(({{max_size}} / 1024 ))"
-	cur_size_kb=$(( $(stat --format='%s' {{binary}}) / 1024 ))
+	max_size_kb="$(({{srv_max_size}} / 1024 ))"
+	cur_size_kb=$(( $(stat --format='%s' {{srv_binary}}) / 1024 ))
 	echo "release binary: ${cur_size_kb}KB / ${max_size_kb}KB"
 	if [ "$cur_size_kb" -gt "$max_size_kb" ]; then
 	  echo "ERROR: release binary exceeds limit"
+	  exit 1
+	fi
+
+[script]
+check_helper_binary_size:
+	cargo build --release
+	max_size_kb="$(({{helper_max_size}} / 1024 ))"
+	cur_size_kb=$(( $(stat --format='%s' {{helper_binary}}) / 1024 ))
+	echo "release varlinkctl-helper binary: ${cur_size_kb}KB / ${max_size_kb}KB"
+	if [ "$cur_size_kb" -gt "$max_size_kb" ]; then
+	  echo "ERROR: release varlinkctl-helper binary exceeds limit"
 	  exit 1
 	fi

--- a/src/bin/varlinkctl-helper.rs
+++ b/src/bin/varlinkctl-helper.rs
@@ -1,0 +1,111 @@
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::os::fd::{FromRawFd, OwnedFd};
+use std::os::unix::net::UnixStream;
+
+use anyhow::{Context, Result, bail};
+use rustix::event::{PollFd, PollFlags, poll};
+use tungstenite::stream::MaybeTlsStream;
+use tungstenite::{Message, WebSocket};
+
+type Ws = WebSocket<MaybeTlsStream<TcpStream>>;
+
+fn ws_url(url: &str) -> String {
+    if let Some(rest) = url.strip_prefix("https://") {
+        format!("wss://{rest}")
+    } else if let Some(rest) = url.strip_prefix("http://") {
+        format!("ws://{rest}")
+    } else {
+        url.to_string()
+    }
+}
+
+fn ws_tcp_stream(ws: &Ws) -> &TcpStream {
+    match ws.get_ref() {
+        MaybeTlsStream::Plain(s) => s,
+        MaybeTlsStream::NativeTls(s) => s.get_ref(),
+        t => panic!("unsupported stream type {t:#?}"),
+    }
+}
+
+fn run() -> Result<()> {
+    let listen_fds: i32 = std::env::var("LISTEN_FDS")
+        .context("LISTEN_FDS is not set")?
+        .parse()
+        .context("LISTEN_FDS is not a valid integer")?;
+    if listen_fds != 1 {
+        bail!("LISTEN_FDS must be 1, got {listen_fds}");
+    }
+
+    // XXX: once https://github.com/systemd/systemd/issues/40640 is implemented
+    // we can remove the env_url and this confusing mach
+    let env_url = std::env::var("VARLINK_BRIDGE_URL").ok();
+    let arg_url = std::env::args().nth(1);
+    let bridge_url = match (env_url, arg_url) {
+        (Some(_), Some(_)) => bail!("cannot set both VARLINK_BRIDGE_URL and argv[1]"),
+        (None, None) => bail!("bridge URL required via VARLINK_BRIDGE_URL or argv[1]"),
+        (Some(url), None) | (None, Some(url)) => url,
+    };
+    let ws_url = ws_url(&bridge_url);
+
+    // Safety: fd 3 is passed to us via the sd_listen_fds() protocol.
+    let fd3 = unsafe { OwnedFd::from_raw_fd(3) };
+    rustix::io::fcntl_getfd(&fd3).context("fd 3 is not valid (LISTEN_FDS protocol error?)")?;
+    let mut fd3 = UnixStream::from(fd3);
+
+    let (mut ws, _) = tungstenite::connect(&ws_url)
+        .with_context(|| format!("WebSocket connect to {ws_url} failed"))?;
+
+    // Set non-blocking so that we deal with incomplete websocket
+    // frames in ws.read() - they return WouldBlock now and we can
+    // continue when waking up from PollFd next time.
+    ws_tcp_stream(&ws).set_nonblocking(true)?;
+
+    let mut buf = vec![0u8; 8192];
+    loop {
+        let mut pollfds = [
+            PollFd::new(&fd3, PollFlags::IN),
+            PollFd::new(ws_tcp_stream(&ws), PollFlags::IN),
+        ];
+        poll(&mut pollfds, None)?;
+        let fd3_revents = pollfds[0].revents();
+        let ws_revents = pollfds[1].revents();
+
+        if fd3_revents.contains(PollFlags::IN) {
+            let n = fd3.read(&mut buf).context("fd3 read")?;
+            if n == 0 {
+                return Ok(());
+            }
+            ws.send(Message::Binary(buf[..n].to_vec().into()))
+                .context("ws send")?;
+        }
+
+        if ws_revents.contains(PollFlags::IN) {
+            loop {
+                match ws.read() {
+                    Ok(Message::Binary(data)) => fd3.write_all(&data).context("fd3 write")?,
+                    Ok(Message::Text(_)) => bail!("unexpected text WebSocket frame"),
+                    Ok(Message::Close(_)) => return Ok(()),
+                    Ok(_) => {}
+                    Err(tungstenite::Error::Io(ref e))
+                        if e.kind() == std::io::ErrorKind::WouldBlock =>
+                    {
+                        break;
+                    }
+                    Err(e) => return Err(e).context("ws read"),
+                }
+            }
+        }
+
+        if fd3_revents.contains(PollFlags::HUP) {
+            return Ok(());
+        }
+    }
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("Error: {e:#}");
+        std::process::exit(1);
+    }
+}


### PR DESCRIPTION
This PR adds websocket support and a varlinkctl-helper that can be used to
bridge from varlinkctl to the varlink-http-bridge.

---

This commit adds websocket support for the varlink bridge. With that we can do:
- pipelining, i.e. multiple calls on a single socket
- support the "more" protocol feature to stream replies
- support for protocol upgrades
- transparent proxying for e.g. varlink --bridge

The websocket speaks the raw varlink protocol, each message is a single websocket message (until the procol is upgraded when this becomes a dumb forwarder).

It unfortunately increases the binary size from 2.8MB to 3.2MB.

---

This commit adds a new `varlinkctl-helper` binary that acts as
a helper binary for varlinkctl to allow varlinkctl to transparently
use the varlink-http-bridge.

It uses the varlinkctl `exec:<path>` feature and connects to the
url provided via `VARLINK_BRIDGE_URL` as a transparent proxy, e.g.:
```console
$ VARLINK_BRIDGE_URL=http://localhost:8080/ws/sockets/io.systemd.Hostname \
    varlinkctl call /usr/libexec/varlinkctl-helper \
    io.systemd.Hostname.Describe {}
...

$ VARLINK_BRIDGE_URL=http://localhost:8080/ws/sockets/io.systemd.Multiplexer \
   varlinkctl call --more /usr/libexec/varlinkctl-helper \
   io.systemd.UserDatabase.GetUserRecord '{"service":"io.systemd.Multiplexer"}'
...
```

Note that once https://github.com/systemd/systemd/issues/40640 is
implemented we can provide transparent support for this and this
just becomes:
```
$ varlinkctl https://example.com/sockets/io.systemd.Hostname \
     io.systemd.Hostname.Described '{}'
```
