### PR TITLE
bridge: add mTLS support based on openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,16 @@ argh = "0.1"
 # not using full regex as it adds more bloat and our requirements are minimal
 regex-lite = "0.1"
 listenfd = "1.0.2"
-tungstenite = { version = "0.28", features = ["native-tls"] }
+tungstenite = "0.28"
 rustix = { version = "1.0", features = ["event"] }
 signal-hook = "0.3"
+# using opeenssl here to keep size small, rusttls adds ~1.8MB binary size
+# and nativetls does not support mTLS
+openssl = "0.10"
+tokio-openssl = "0.6"
 
 [dev-dependencies]
-reqwest = { version = "0.12", default-features = false, features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls"] }
 test-with = { version = "0.14", default-features = false, features = ["runtime"] }
 scopeguard = "1.2"
 gethostname = "1.1.0"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ This makes the bridge compatible with libvarlink `varlink --brige`
 via `websocat --binary`, enabling full varlink features (including
 `--more`) over the network.
 
-
 ## Examples (curl)
 
 Using curl for direct calls is usually more convenient/ergonimic than
@@ -164,4 +163,64 @@ $ varlink --bridge "websocat --binary ws://localhost:8080/ws/sockets/io.systemd.
   ...
 }
 
+```
+
+## TLS / mTLS
+
+TLS flag names follow the Kubernetes API server convention.
+
+```
+--tls-cert-file        path to TLS certificate PEM file
+--tls-private-key-file path to TLS private key PEM file
+--client-ca-file       path to CA certificate PEM for client verification (mTLS)
+```
+
+Providing `--client-ca-file` implicitly enables mTLS: the server will
+require clients to present a certificate signed by that CA.
+
+### systemd credentials
+
+When running as a systemd service, the bridge automatically discovers
+TLS material from `$CREDENTIALS_DIRECTORY` (see `systemd.exec(5)`).
+The credential file names match the CLI flag names:
+
+```ini
+[Service]
+LoadCredential=tls-cert-file:/etc/ssl/certs/bridge.pem
+LoadCredential=tls-private-key-file:/etc/ssl/private/bridge.pem
+LoadCredential=client-ca-file:/etc/ssl/ca/client-ca.pem
+```
+
+Explicit CLI flags take priority over credentials directory files.
+
+### Client (varlinkctl-helper)
+
+The `varlinkctl-helper` binary acts as a bridge between `varlinkctl`
+and `varlink-http-bridge`, supporting TLS and mTLS. It looks for
+client credentials in the first existing directory:
+
+* `$XDG_CONFIG_HOME/varlink-http-bridge/`
+* `~/.config/varlink-http-bridge/`
+* `$CREDENTIALS_DIRECTORY`
+
+The credential file names are:
+
+| File                   | Purpose                                   |
+|------------------------|-------------------------------------------|
+| `client-cert-file`     | Client certificate PEM (for mTLS)         |
+| `client-key-file`      | Client private key PEM (for mTLS)         |
+| `server-ca-file`       | CA certificate PEM (for private/self-signed server CAs) |
+
+The system CAs are used automatically. For mTLS, drop the client cert
+and key into the config directory:
+
+```console
+$ mkdir -p ~/.config/varlink-http-bridge
+$ cp client-cert.pem ~/.config/varlink-http-bridge/client-cert-file
+$ cp client-key.pem  ~/.config/varlink-http-bridge/client-key-file
+$ cp ca.pem          ~/.config/varlink-http-bridge/server-ca-file
+
+$ VARLINK_BRIDGE_URL=https://myhost:8080/ws/sockets/io.systemd.Hostname \
+    varlinkctl call exec:/usr/libexec/varlinkctl-helper \
+    io.systemd.Hostname.Describe '{}'
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,6 +190,100 @@ async fn get_varlink_connection_with_validate_socket(
     Ok(connection)
 }
 
+struct TlsListener {
+    inner: TcpListener,
+    acceptor: openssl::ssl::SslAcceptor,
+}
+
+impl axum::serve::Listener for TlsListener {
+    type Io = tokio_openssl::SslStream<tokio::net::TcpStream>;
+    type Addr = std::net::SocketAddr;
+
+    async fn accept(&mut self) -> (Self::Io, Self::Addr) {
+        loop {
+            let res: Result<_, Box<dyn std::error::Error>> = async {
+                let (stream, addr) = self
+                    .inner
+                    .accept()
+                    .await
+                    .map_err(|e| format!("TCP accept failed: {e}"))?;
+                let ssl = openssl::ssl::Ssl::new(self.acceptor.context())
+                    .map_err(|e| format!("SSL context error: {e}"))?;
+                let mut tls_stream = tokio_openssl::SslStream::new(ssl, stream)
+                    .map_err(|e| format!("SSL stream creation failed: {e}"))?;
+                std::pin::Pin::new(&mut tls_stream)
+                    .accept()
+                    .await
+                    .map_err(|e| format!("TLS handshake failed: {e}"))?;
+                Ok((tls_stream, addr))
+            }
+            .await;
+
+            match res {
+                Ok(conn) => return conn,
+                Err(e) => warn!("{e}"),
+            }
+        }
+    }
+
+    fn local_addr(&self) -> std::io::Result<Self::Addr> {
+        self.inner.local_addr()
+    }
+}
+
+fn load_tls_acceptor(
+    cert_path: &str,
+    key_path: &str,
+    client_ca_path: Option<&str>,
+) -> anyhow::Result<openssl::ssl::SslAcceptor> {
+    use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod, SslVerifyMode};
+
+    let mut builder = SslAcceptor::mozilla_modern_v5(SslMethod::tls_server())?;
+    builder.set_certificate_chain_file(cert_path)?;
+    builder.set_private_key_file(key_path, SslFiletype::PEM)?;
+    builder.check_private_key()?;
+
+    if let Some(ca_path) = client_ca_path {
+        builder.set_ca_file(ca_path)?;
+        builder.set_verify(SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT);
+    }
+
+    Ok(builder.build())
+}
+
+/// Resolve TLS configuration: explicit paths take priority, then fall back to
+/// systemd's $`CREDENTIALS_DIRECTORY` (see systemd.exec(5)), then no TLS.
+/// Credential file names match the CLI flag names: tls-cert-file,
+/// tls-private-key-file, client-ca-file.
+fn resolve_tls_acceptor(
+    cli_cert: Option<String>,
+    cli_key: Option<String>,
+    cli_ca: Option<String>,
+    creds_dir: Option<&std::path::Path>,
+) -> anyhow::Result<Option<openssl::ssl::SslAcceptor>> {
+    let cred = |name: &str| -> Option<String> {
+        creds_dir
+            .map(|d| d.join(name))
+            .filter(|p| p.exists())
+            .and_then(|p| p.to_str().map(String::from))
+    };
+
+    let tls_cert = cli_cert.or_else(|| cred("tls-cert-file"));
+    let tls_key = cli_key.or_else(|| cred("tls-private-key-file"));
+    let client_ca = cli_ca.or_else(|| cred("client-ca-file"));
+
+    match (tls_cert.as_deref(), tls_key.as_deref()) {
+        (Some(cert), Some(key)) => Ok(Some(load_tls_acceptor(cert, key, client_ca.as_deref())?)),
+        (None, None) => {
+            if client_ca.is_some() {
+                bail!("--client-ca-file requires --tls-cert-file and --tls-private-key-file");
+            }
+            Ok(None)
+        }
+        _ => bail!("--tls-cert-file and --tls-private-key-file must be specified together"),
+    }
+}
+
 #[derive(Clone)]
 struct AppState {
     varlink_sockets: Arc<VarlinkSockets>,
@@ -444,11 +538,26 @@ async fn shutdown_signal() {
     println!("Shutdown signal received, stopping server...");
 }
 
-async fn run_server(varlink_sockets_path: &str, listener: TcpListener) -> anyhow::Result<()> {
+async fn run_server(
+    varlink_sockets_path: &str,
+    listener: TcpListener,
+    tls_acceptor: Option<openssl::ssl::SslAcceptor>,
+) -> anyhow::Result<()> {
     let app = create_router(varlink_sockets_path)?;
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
-        .await?;
+
+    if let Some(acceptor) = tls_acceptor {
+        let tls_listener = TlsListener {
+            inner: listener,
+            acceptor,
+        };
+        axum::serve(tls_listener, app)
+            .with_graceful_shutdown(shutdown_signal())
+            .await?;
+    } else {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown_signal())
+            .await?;
+    }
 
     Ok(())
 }
@@ -464,6 +573,22 @@ struct Cli {
     /// varlink unix socket path to proxy: a directory of sockets/symlinks or a single socket
     #[argh(positional, default = "String::from(\"/run/systemd/registry\")")]
     varlink_sockets_path: String,
+
+    // TLS flag names follow the Kubernetes API server convention
+    // (--tls-cert-file, --tls-private-key-file, --client-ca-file).
+    // Providing --client-ca-file implicitly enables mTLS client
+    // certificate verification.
+    /// path to TLS certificate PEM file
+    #[argh(option)]
+    tls_cert_file: Option<String>,
+
+    /// path to TLS private key PEM file
+    #[argh(option)]
+    tls_private_key_file: Option<String>,
+
+    /// path to CA certificate PEM file for client certificate verification (mTLS)
+    #[argh(option)]
+    client_ca_file: Option<String>,
 }
 
 #[tokio::main]
@@ -483,14 +608,28 @@ async fn main() -> anyhow::Result<()> {
     } else {
         TcpListener::bind(&cli.bind).await?
     };
+
+    let creds_dir = std::env::var_os("CREDENTIALS_DIRECTORY").map(std::path::PathBuf::from);
+    let tls_acceptor = resolve_tls_acceptor(
+        cli.tls_cert_file,
+        cli.tls_private_key_file,
+        cli.client_ca_file,
+        creds_dir.as_deref(),
+    )?;
+
     let local_addr = listener.local_addr()?;
+    let scheme = if tls_acceptor.is_some() {
+        "HTTPS"
+    } else {
+        "HTTP"
+    };
 
     eprintln!("Varlink proxy started");
     eprintln!(
-        "Forwarding HTTP {local_addr} -> Varlink: {varlink_sockets_path}",
+        "Forwarding {scheme} {local_addr} -> Varlink: {varlink_sockets_path}",
         varlink_sockets_path = &cli.varlink_sockets_path
     );
-    run_server(&cli.varlink_sockets_path, listener).await
+    run_server(&cli.varlink_sockets_path, listener, tls_acceptor).await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
We need support for TLS in the bridge and we also want to support mTLS to (optionally) only allow clients with the right client cert to connect. This commit adds this via the openssl crate. We use this instead of nativetls because nativetls does not provide mTLS support (easily). We do not use rusttls because it would increase the binary size too much.

This also includes an update to the varlinkctl-helper to support mtls. Note that `varlinkctl exec:` does not support passing commandline options so the certs to use are loaded from {$XDG_CONFIG_HOME,config}/varlink-http-bridge/ and $CREDENTIALS_DIRECTORY (in this order).