### PR TITLE
test: use podman to run tests inside container with latest  systemd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,4 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: extractions/setup-just@v3
-      - run: just test
+      - run: just test-in-container

--- a/Containerfile.test
+++ b/Containerfile.test
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+FROM registry.fedoraproject.org/fedora:44
+RUN dnf install -y systemd cargo rust gcc openssl-devel openssl openssh-clients pkg-config && dnf clean all
+CMD ["/sbin/init"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ http. The main use case is systemd, so only the subset of varlink that
 systemd needs is supported right now.
 
 It takes a directory with varlink sockets (or symlinks to varlink
-sockets) like /run/systemd/registry as the argument and will server
+sockets) like /run/varlink/registry as the argument and will server
 whatever it find in there. Sockets can be added or removed dynamically
 in the dir as needed.
 

--- a/justfile
+++ b/justfile
@@ -25,8 +25,8 @@ check: check_srv_binary_size check_helper_binary_size
 	cargo fmt --check
 	cargo clippy -- -W clippy::pedantic
 
-test:
-	cargo test
+test *args:
+	cargo test {{args}}
 
 # the httpd service
 srv_binary := "target/release/varlink-http-bridge"
@@ -59,3 +59,22 @@ check_helper_binary_size:
 	  echo "ERROR: release varlinkctl-helper binary exceeds limit"
 	  exit 1
 	fi
+
+container_image := "varlink-http-bridge-test"
+container_name := "vhb-test"
+
+# Run cargo test inside a Fedora system container (systemd as PID 1)
+[script]
+test-in-container *args:
+	if ! podman image exists "{{container_image}}"; then
+	  podman build -t "{{container_image}}" -f Containerfile.test .
+	fi
+	podman rm -f "{{container_name}}" 2>/dev/null || true
+	trap 'podman rm -f "{{container_name}}"' EXIT
+	podman run -d --systemd=true \
+	  --name "{{container_name}}" \
+	  -v .:/srv/varlink-http-bridge:z \
+	  -w /srv/varlink-http-bridge \
+	  "{{container_image}}"
+	podman exec "{{container_name}}" systemctl is-system-running --wait || true
+	podman exec "{{container_name}}" cargo test {{args}}

--- a/src/main.rs
+++ b/src/main.rs
@@ -675,7 +675,7 @@ fn print_help() {
 
         Positional arguments:
           VARLINK_SOCKETS_PATH  directory of sockets or a single socket
-                                (default: /run/systemd/registry)
+                                (default: /run/varlink/registry)
 
         Options:
           --bind=ADDR             address to bind HTTP server to (default: 0.0.0.0:1031)
@@ -711,7 +711,7 @@ fn parse_cli() -> anyhow::Result<Command> {
     use lexopt::prelude::*;
 
     let mut bind = String::from("0.0.0.0:1031");
-    let mut varlink_sockets_path = String::from("/run/systemd/registry");
+    let mut varlink_sockets_path = String::from("/run/varlink/registry");
     let mut cert = None;
     let mut key = None;
     let mut trust = None;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -46,10 +46,10 @@ async fn run_test_server_with_auth(
     (task_handle, local_addr)
 }
 
-#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[test_with::path(/run/varlink/registry/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_integration_real_systemd_hostname_post() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
+    let (server, local_addr) = run_test_server("/run/varlink/registry").await;
     defer! {
         server.abort();
     };
@@ -69,10 +69,10 @@ async fn test_integration_real_systemd_hostname_post() {
     assert!(body["Hostname"].as_str().is_some_and(|h| !h.is_empty()));
 }
 
-#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[test_with::path(/run/varlink/registry/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_integration_real_systemd_socket_get() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
+    let (server, local_addr) = run_test_server("/run/varlink/registry").await;
     defer! {
         server.abort();
     };
@@ -88,10 +88,10 @@ async fn test_integration_real_systemd_socket_get() {
     assert_eq!(body["product"], "systemd (systemd-hostnamed)");
 }
 
-#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[test_with::path(/run/varlink/registry/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_integration_real_systemd_sockets_get() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
+    let (server, local_addr) = run_test_server("/run/varlink/registry").await;
     defer! {
         server.abort();
     };
@@ -112,10 +112,10 @@ async fn test_integration_real_systemd_sockets_get() {
     );
 }
 
-#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[test_with::path(/run/varlink/registry/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_integration_real_systemd_socket_interface_get() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
+    let (server, local_addr) = run_test_server("/run/varlink/registry").await;
     defer! {
         server.abort();
     };
@@ -134,10 +134,10 @@ async fn test_integration_real_systemd_socket_interface_get() {
     assert_eq!(body.get("method_names").unwrap(), &json!(["Describe"]));
 }
 
-#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[test_with::path(/run/varlink/registry/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_integration_real_systemd_hostname_parallel() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
+    let (server, local_addr) = run_test_server("/run/varlink/registry").await;
     defer! {
         server.abort();
     };
@@ -176,10 +176,10 @@ async fn test_integration_real_systemd_hostname_parallel() {
     assert_eq!(count, NUM_TASKS);
 }
 
-#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[test_with::path(/run/varlink/registry/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_integration_real_systemd_socket_query_param() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
+    let (server, local_addr) = run_test_server("/run/varlink/registry").await;
     defer! {
         server.abort();
     };
@@ -199,10 +199,10 @@ async fn test_integration_real_systemd_socket_query_param() {
     assert_eq!(body["product"], "systemd (systemd-hostnamed)");
 }
 
-#[test_with::path(/run/systemd)]
+#[test_with::path(/run/varlink/registry)]
 #[tokio::test]
 async fn test_error_bad_request_on_malformed_json() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
+    let (server, local_addr) = run_test_server("/run/varlink/registry").await;
     defer! {
         server.abort();
     };
@@ -222,10 +222,10 @@ async fn test_error_bad_request_on_malformed_json() {
     assert_eq!(res.status(), StatusCode::BAD_REQUEST);
 }
 
-#[test_with::path(/run/systemd)]
+#[test_with::path(/run/varlink/registry)]
 #[tokio::test]
 async fn test_error_unknown_varlink_address() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
+    let (server, local_addr) = run_test_server("/run/varlink/registry").await;
     defer! {
         server.abort();
     };
@@ -248,10 +248,10 @@ async fn test_error_unknown_varlink_address() {
     assert_eq!(body["error"], "IO error");
 }
 
-#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[test_with::path(/run/varlink/registry/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_error_404_for_missing_method() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
+    let (server, local_addr) = run_test_server("/run/varlink/registry").await;
     defer! {
         server.abort();
     };
@@ -272,10 +272,10 @@ async fn test_error_404_for_missing_method() {
     assert_eq!(body["error"], "Method not found: 'com.missing.Call'");
 }
 
-#[test_with::path(/run/systemd)]
+#[test_with::path(/run/varlink/registry)]
 #[tokio::test]
 async fn test_error_bad_request_for_unclean_address() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
+    let (server, local_addr) = run_test_server("/run/varlink/registry").await;
     defer! {
         server.abort();
     };
@@ -300,10 +300,10 @@ async fn test_error_bad_request_for_unclean_address() {
     );
 }
 
-#[test_with::path(/run/systemd)]
+#[test_with::path(/run/varlink/registry)]
 #[tokio::test]
 async fn test_error_bad_request_for_invalid_chars_in_address() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
+    let (server, local_addr) = run_test_server("/run/varlink/registry").await;
     defer! {
         server.abort();
     };
@@ -328,10 +328,10 @@ async fn test_error_bad_request_for_invalid_chars_in_address() {
     );
 }
 
-#[test_with::path(/run/systemd)]
+#[test_with::path(/run/varlink/registry)]
 #[tokio::test]
 async fn test_error_bad_request_for_method_without_dots() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
+    let (server, local_addr) = run_test_server("/run/varlink/registry").await;
     defer! {
         server.abort();
     };
@@ -352,10 +352,10 @@ async fn test_error_bad_request_for_method_without_dots() {
     );
 }
 
-#[test_with::path(/run/systemd)]
+#[test_with::path(/run/varlink/registry)]
 #[tokio::test]
 async fn test_health_endpoint() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
+    let (server, local_addr) = run_test_server("/run/varlink/registry").await;
     defer! {
         server.abort();
     };
@@ -387,10 +387,10 @@ async fn test_varlink_sockets_dir_or_file_missing() {
     );
 }
 
-#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[test_with::path(/run/varlink/registry/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_single_socket_post() {
-    let (server, local_addr) = run_test_server("/run/systemd/io.systemd.Hostname").await;
+    let (server, local_addr) = run_test_server("/run/varlink/registry/io.systemd.Hostname").await;
     defer! {
         server.abort();
     };
@@ -410,10 +410,10 @@ async fn test_single_socket_post() {
     assert!(body["Hostname"].as_str().is_some_and(|h| !h.is_empty()));
 }
 
-#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[test_with::path(/run/varlink/registry/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_single_socket_rejects_wrong_name() {
-    let (server, local_addr) = run_test_server("/run/systemd/io.systemd.Hostname").await;
+    let (server, local_addr) = run_test_server("/run/varlink/registry/io.systemd.Hostname").await;
     defer! {
         server.abort();
     };
@@ -436,13 +436,13 @@ async fn test_single_socket_rejects_wrong_name() {
     );
 }
 
-#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[test_with::path(/run/varlink/registry/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_varlink_unix_sockets_in_follows_symlinks() {
     let tmpdir = tempfile::tempdir().expect("failed to create tempdir");
     let symlink_path = tmpdir.path().join("io.systemd.Hostname");
 
-    std::os::unix::fs::symlink("/run/systemd/io.systemd.Hostname", &symlink_path)
+    std::os::unix::fs::symlink("/run/varlink/registry/io.systemd.Hostname", &symlink_path)
         .expect("failed to create symlink");
 
     let dir_fd = OwnedFd::from(std::fs::File::open(tmpdir.path()).unwrap());
@@ -451,13 +451,13 @@ async fn test_varlink_unix_sockets_in_follows_symlinks() {
     assert_eq!(sockets, vec!["io.systemd.Hostname"]);
 }
 
-#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[test_with::path(/run/varlink/registry/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_varlink_unix_sockets_in_skips_dangling_symlinks() {
     let tmpdir = tempfile::tempdir().expect("failed to create tempdir");
 
     let good = tmpdir.path().join("io.systemd.Hostname");
-    std::os::unix::fs::symlink("/run/systemd/io.systemd.Hostname", &good)
+    std::os::unix::fs::symlink("/run/varlink/registry/io.systemd.Hostname", &good)
         .expect("failed to create symlink");
 
     let bad = tmpdir.path().join("io.example.Bad");
@@ -472,10 +472,10 @@ async fn test_varlink_unix_sockets_in_skips_dangling_symlinks() {
     assert_eq!(sockets, vec!["io.systemd.Hostname"]);
 }
 
-#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[test_with::path(/run/varlink/registry/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_ws_hostname_describe() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
+    let (server, local_addr) = run_test_server("/run/varlink/registry").await;
     defer! {
         server.abort();
     };
@@ -506,15 +506,15 @@ async fn test_ws_hostname_describe() {
     assert_eq!(body["parameters"]["Hostname"], expected_hostname);
 }
 
-#[test_with::path(/run/systemd/userdb/io.systemd.Multiplexer)]
+#[test_with::path(/run/varlink/registry/io.systemd.UserDatabase)]
 #[tokio::test]
 async fn test_ws_userdb_get_user_record_more() {
-    let (server, local_addr) = run_test_server("/run/systemd/userdb").await;
+    let (server, local_addr) = run_test_server("/run/varlink/registry").await;
     defer! {
         server.abort();
     };
 
-    let url = format!("ws://{local_addr}/ws/sockets/io.systemd.Multiplexer");
+    let url = format!("ws://{local_addr}/ws/sockets/io.systemd.UserDatabase");
     let (mut ws, _) = tokio_tungstenite::connect_async(&url)
         .await
         .expect("WS connect failed");
@@ -569,10 +569,10 @@ async fn test_ws_userdb_get_user_record_more() {
 }
 
 #[test_with::path(/usr/bin/varlinkctl)]
-#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[test_with::path(/run/varlink/registry/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_varlinkctl_helper_hostname_describe() {
-    let (server, local_addr) = run_test_server("/run/systemd").await;
+    let (server, local_addr) = run_test_server("/run/varlink/registry").await;
     defer! {
         server.abort();
     };
@@ -607,15 +607,15 @@ async fn test_varlinkctl_helper_hostname_describe() {
 }
 
 #[test_with::path(/usr/bin/varlinkctl)]
-#[test_with::path(/run/systemd/userdb/io.systemd.Multiplexer)]
+#[test_with::path(/run/varlink/registry/io.systemd.UserDatabase)]
 #[tokio::test]
 async fn test_varlinkctl_helper_userdb_get_user_record() {
-    let (server, local_addr) = run_test_server("/run/systemd/userdb").await;
+    let (server, local_addr) = run_test_server("/run/varlink/registry").await;
     defer! {
         server.abort();
     };
 
-    let bridge_url = format!("http://{local_addr}/ws/sockets/io.systemd.Multiplexer");
+    let bridge_url = format!("http://{local_addr}/ws/sockets/io.systemd.UserDatabase");
     let output = tokio::process::Command::new("varlinkctl")
         .args([
             "call",
@@ -895,7 +895,7 @@ async fn test_tls_credentials_directory_fallback() {
 }
 
 #[test_with::path(/usr/bin/varlinkctl)]
-#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[test_with::path(/run/varlink/registry/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_varlinkctl_helper_mtls_hostname_describe() {
     let pki = make_test_pki();
@@ -907,7 +907,7 @@ async fn test_varlinkctl_helper_mtls_hostname_describe() {
     )
     .unwrap();
 
-    let (server, local_addr) = run_test_tls_server("/run/systemd", acceptor).await;
+    let (server, local_addr) = run_test_tls_server("/run/varlink/registry", acceptor).await;
     defer! {
         server.abort();
     };
@@ -954,7 +954,7 @@ async fn test_varlinkctl_helper_mtls_hostname_describe() {
 }
 
 #[test_with::path(/usr/bin/varlinkctl)]
-#[test_with::path(/run/systemd/io.systemd.Hostname)]
+#[test_with::path(/run/varlink/registry/io.systemd.Hostname)]
 #[tokio::test]
 async fn test_varlinkctl_helper_mtls_no_client_cert() {
     let pki = make_test_pki();
@@ -966,7 +966,7 @@ async fn test_varlinkctl_helper_mtls_no_client_cert() {
     )
     .unwrap();
 
-    let (server, local_addr) = run_test_tls_server("/run/systemd", acceptor).await;
+    let (server, local_addr) = run_test_tls_server("/run/varlink/registry", acceptor).await;
     defer! {
         server.abort();
     };


### PR DESCRIPTION
[draft as it would be nice(r) to find a native systemd way to test this]

This ensures that we run the tests against latest systemd.
