### PR TITLE
auth: add tls channel binding (RFC 9266) to sshauth

### DIFF
--- a/src/auth_ssh.rs
+++ b/src/auth_ssh.rs
@@ -239,6 +239,7 @@ impl Authenticator for SshKeyAuthenticator {
         path: &str,
         auth_header: &str,
         nonce: Option<&str>,
+        tls_channel_binding: Option<&str>,
     ) -> anyhow::Result<()> {
         self.maybe_reload();
 
@@ -265,6 +266,10 @@ impl Authenticator for SshKeyAuthenticator {
             .action("method", method)
             .action("path", path)
             .action("nonce", nonce)
+            .action(
+                "tls-channel-binding",
+                tls_channel_binding.unwrap_or_default(),
+            )
             .with_keys(&authorized_keys)
             .context("token verification failed")?;
 

--- a/src/bin/varlinkctl-helper/main.rs
+++ b/src/bin/varlinkctl-helper/main.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use log::warn;
-use openssl::ssl::{SslConnector, SslFiletype, SslMethod};
+use openssl::ssl::{SslConnector, SslFiletype, SslMethod, SslVersion};
 use rustix::event::{PollFd, PollFlags, poll};
 use tungstenite::{Message, WebSocket};
 
@@ -24,6 +24,7 @@ use sshauth_client::maybe_add_auth_headers;
 fn maybe_add_auth_headers(
     _request: &mut tungstenite::http::Request<()>,
     _uri: &tungstenite::http::Uri,
+    _tls_channel_binding: Option<&str>,
 ) -> Result<()> {
     Ok(())
 }
@@ -74,6 +75,9 @@ fn ws_tcp_stream(ws: &Ws) -> &TcpStream {
 /// 3. `$CREDENTIALS_DIRECTORY` (systemd, see systemd.exec(5))
 fn build_ssl_connector() -> Result<SslConnector> {
     let mut builder = SslConnector::builder(SslMethod::tls_client())?;
+    // We need tls channel binding per RFC 9266 ("tls-exporter") which
+    // is only guaranteed unique with TLS 1.3.
+    builder.set_min_proto_version(Some(SslVersion::TLS1_3))?;
 
     let maybe_credentials_dirs = [
         std::env::var_os("XDG_CONFIG_HOME").map(|d| PathBuf::from(d).join("varlink-http-bridge")),
@@ -139,6 +143,19 @@ fn connect_ws(url: &str) -> Result<Ws> {
             Stream::Plain(tcp)
         };
 
+    let tls_channel_binding = match &stream {
+        Stream::Tls(ssl_stream) => {
+            use varlink_http_bridge::{TLS_CHANNEL_BINDING_LABEL, TLS_CHANNEL_BINDING_LEN};
+            let mut buf = [0u8; TLS_CHANNEL_BINDING_LEN];
+            ssl_stream
+                .ssl()
+                .export_keying_material(&mut buf, TLS_CHANNEL_BINDING_LABEL, Some(&[]))
+                .expect("export_keying_material must succeed after TLS 1.3 handshake");
+            Some(openssl::base64::encode_block(&buf))
+        }
+        Stream::Plain(_) => None,
+    };
+
     // Use into_client_request() here as it auto-generates standard WS upgrade headers,
     // then we add our auth headers too
     let mut request = ws_url
@@ -147,7 +164,7 @@ fn connect_ws(url: &str) -> Result<Ws> {
 
     // this adds ssh auth headers if ssh-agent is available, once we have more auth methods
     // it may add more
-    maybe_add_auth_headers(&mut request, &uri)?;
+    maybe_add_auth_headers(&mut request, &uri, tls_channel_binding.as_deref())?;
 
     let ws_context = if use_tls {
         "WebSocket handshake failed: check client cert if server requires mTLS"

--- a/src/bin/varlinkctl-helper/sshauth_client.rs
+++ b/src/bin/varlinkctl-helper/sshauth_client.rs
@@ -26,12 +26,13 @@ static TOKIO_RT: std::sync::LazyLock<tokio::runtime::Runtime> = std::sync::LazyL
 pub(crate) fn maybe_add_auth_headers(
     request: &mut tungstenite::http::Request<()>,
     uri: &tungstenite::http::Uri,
+    tls_channel_binding: Option<&str>,
 ) -> Result<()> {
     let path_and_query = uri
         .path_and_query()
         .map_or(uri.path(), tungstenite::http::uri::PathAndQuery::as_str);
 
-    let (bearer, nonce) = match build_auth_token("GET", path_and_query) {
+    let (bearer, nonce) = match build_auth_token("GET", path_and_query, tls_channel_binding) {
         Ok(Some((bearer, nonce))) => (bearer, nonce),
         Ok(None) => return Ok(()),
         Err(e) => {
@@ -53,7 +54,11 @@ pub(crate) fn maybe_add_auth_headers(
 /// Build an SSH auth token for the given HTTP method and path.
 ///
 /// Returns `Ok(None)` when no SSH credentials are available.
-fn build_auth_token(method: &str, path_and_query: &str) -> Result<Option<(String, String)>> {
+fn build_auth_token(
+    method: &str,
+    path_and_query: &str,
+    tls_channel_binding: Option<&str>,
+) -> Result<Option<(String, String)>> {
     // The sshauth crate is async so we need to run this inside an async context
     TOKIO_RT.block_on(async {
         let Some(mut signer) = build_signer().await? else {
@@ -75,7 +80,12 @@ fn build_auth_token(method: &str, path_and_query: &str) -> Result<Option<(String
         let mut tb = token_signer.sign_for();
         tb.action("method", method)
             .action("path", path_and_query)
-            .action("nonce", &nonce);
+            .action("nonce", &nonce)
+            .action(
+                "tls-channel-binding",
+                tls_channel_binding.unwrap_or_default(),
+            );
+
         let token: sshauth::token::Token = tb.sign().await?;
         Ok(Some((format!("Bearer {}", token.encode()), nonce)))
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,13 @@ pub const SSHAUTH_MAGIC_PREFIX: [u8; 8] = *b"vhbridge";
 /// HTTP header carrying the random nonce that is included in the signed
 /// token payload to prevent replay attacks.
 pub const SSHAUTH_NONCE_HEADER: &str = "x-auth-nonce";
+
+/// TLS channel binding label per RFC 9266 (`tls-exporter`).
+///
+/// Both client and server call `export_keying_material()` with this label
+/// and include the result in the sshauth token so that the signature is
+/// bound to the specific TLS session, preventing credential relay attacks.
+pub const TLS_CHANNEL_BINDING_LABEL: &str = "EXPORTER-Channel-Binding";
+
+/// Output length (bytes) for TLS channel binding export.
+pub const TLS_CHANNEL_BINDING_LEN: usize = 32;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, bail};
 use axum::{
     Router,
     extract::ws::{Message, WebSocket, WebSocketUpgrade},
-    extract::{DefaultBodyLimit, Path, Query, State},
+    extract::{ConnectInfo, DefaultBodyLimit, Path, Query, State},
     http::StatusCode,
     middleware::Next,
     response::{IntoResponse, Response},
@@ -244,6 +244,33 @@ impl axum::serve::Listener for TlsListener {
     }
 }
 
+#[derive(Clone)]
+struct TlsConnectionInfo {
+    tls_channel_binding: Option<String>,
+}
+
+use axum::extract::connect_info::Connected;
+use axum::serve::IncomingStream;
+
+impl Connected<IncomingStream<'_, TlsListener>> for TlsConnectionInfo {
+    fn connect_info(target: IncomingStream<'_, TlsListener>) -> Self {
+        use varlink_http_bridge::{TLS_CHANNEL_BINDING_LABEL, TLS_CHANNEL_BINDING_LEN};
+
+        let mut buf = [0u8; TLS_CHANNEL_BINDING_LEN];
+        target
+            .io()
+            .ssl()
+            .export_keying_material(&mut buf, TLS_CHANNEL_BINDING_LABEL, Some(&[]))
+            // this should never fail after the connection is established
+            // unless something else is in a catastrophic state (like
+            // OOM)
+            .expect("export_keying_material must succeed after TLS 1.3 handshake");
+        TlsConnectionInfo {
+            tls_channel_binding: Some(openssl::base64::encode_block(&buf)),
+        }
+    }
+}
+
 fn load_tls_acceptor(
     cert_path: &str,
     key_path: &str,
@@ -303,6 +330,7 @@ trait Authenticator: Send + Sync {
         path: &str,
         auth_header: &str,
         nonce: Option<&str>,
+        channel_binding: Option<&str>,
     ) -> anyhow::Result<()>;
 }
 
@@ -337,6 +365,11 @@ async fn auth_middleware(
 
     let nonce = extract_nonce(request.headers());
 
+    let tls_channel_binding: Option<String> = request
+        .extensions()
+        .get::<ConnectInfo<TlsConnectionInfo>>()
+        .and_then(|ci| ci.0.tls_channel_binding.clone());
+
     let method = request.method().as_str().to_string();
     let path = request
         .uri()
@@ -346,7 +379,13 @@ async fn auth_middleware(
 
     let mut errors = Vec::new();
     for authenticator in state.authenticators.iter() {
-        match authenticator.check_request(&method, &path, &auth_header, nonce.as_deref()) {
+        match authenticator.check_request(
+            &method,
+            &path,
+            &auth_header,
+            nonce.as_deref(),
+            tls_channel_binding.as_deref(),
+        ) {
             Ok(()) => return next.run(request).await,
             Err(e) => errors.push(e.to_string()),
         }
@@ -639,9 +678,12 @@ async fn run_server(
             inner: listener,
             acceptor,
         };
-        axum::serve(tls_listener, app)
-            .with_graceful_shutdown(shutdown_signal())
-            .await?;
+        axum::serve(
+            tls_listener,
+            app.into_make_service_with_connect_info::<TlsConnectionInfo>(),
+        )
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
     } else {
         axum::serve(listener, app)
             .with_graceful_shutdown(shutdown_signal())

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -751,6 +751,14 @@ async fn run_test_tls_server(
     varlink_sockets_path: &str,
     tls_acceptor: openssl::ssl::SslAcceptor,
 ) -> (tokio::task::JoinHandle<()>, std::net::SocketAddr) {
+    run_test_tls_server_with_auth(varlink_sockets_path, tls_acceptor, Vec::new()).await
+}
+
+async fn run_test_tls_server_with_auth(
+    varlink_sockets_path: &str,
+    tls_acceptor: openssl::ssl::SslAcceptor,
+    authenticators: Vec<Box<dyn Authenticator>>,
+) -> (tokio::task::JoinHandle<()>, std::net::SocketAddr) {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind to random port failed");
@@ -764,7 +772,7 @@ async fn run_test_tls_server(
             &varlink_sockets_path,
             listener,
             Some(tls_acceptor),
-            Vec::new(),
+            authenticators,
         )
         .await
         .expect("server failed")
@@ -1153,7 +1161,7 @@ mod sshauth_tests {
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
         let header = format!("Bearer {}", token.encode());
-        let result = auth.check_request("GET", "/sockets", &header, Some(nonce));
+        let result = auth.check_request("GET", "/sockets", &header, Some(nonce), None);
         assert!(result.is_err(), "expired token should be rejected");
     }
 
@@ -1170,15 +1178,7 @@ mod sshauth_tests {
 
         // Key B: NOT in authorized_keys
         let tmpdir_b = tempfile::tempdir().unwrap();
-        let key_path_b = tmpdir_b.path().join("key_b");
-        let status = std::process::Command::new("ssh-keygen")
-            .args(["-t", "ed25519", "-f"])
-            .arg(&key_path_b)
-            .args(["-N", "", "-q"])
-            .status()
-            .unwrap();
-        assert!(status.success());
-
+        let (_, key_path_b) = generate_ed25519_keypair(tmpdir_b.path());
         let privkey_b_pem = std::fs::read_to_string(&key_path_b).unwrap();
         let privkey_b = ssh_key::PrivateKey::from_openssh(&privkey_b_pem).unwrap();
 
@@ -1194,7 +1194,7 @@ mod sshauth_tests {
         let token = tb.sign().await.unwrap();
 
         let header = format!("Bearer {}", token.encode());
-        let result = auth.check_request("GET", "/sockets", &header, Some(nonce));
+        let result = auth.check_request("GET", "/sockets", &header, Some(nonce), None);
         assert!(result.is_err());
         assert!(
             result
@@ -1222,14 +1222,17 @@ mod sshauth_tests {
         let signer = builder.build().unwrap();
 
         let nonce = "test-nonce-verify12345";
+        let cb = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
         let mut tb = signer.sign_for();
         tb.action("method", "GET")
             .action("path", "/sockets")
-            .action("nonce", nonce);
+            .action("nonce", nonce)
+            .action("tls-channel-binding", cb);
         let token = tb.sign().await.unwrap();
 
         let header = format!("Bearer {}", token.encode());
-        auth.check_request("GET", "/sockets", &header, Some(nonce))
+        auth.check_request("GET", "/sockets", &header, Some(nonce), Some(cb))
             .expect("valid ed25519 token should pass");
     }
 
@@ -1311,6 +1314,7 @@ mod sshauth_tests {
             _path: &str,
             _auth_header: &str,
             _nonce: Option<&str>,
+            _channel_binding: Option<&str>,
         ) -> anyhow::Result<()> {
             anyhow::bail!("{}", self.0)
         }
@@ -1408,19 +1412,22 @@ mod sshauth_tests {
         let signer = builder.build().unwrap();
 
         let nonce = "replay-me12345678";
+        let cb = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
         let mut tb = signer.sign_for();
         tb.action("method", "GET")
             .action("path", "/sockets")
-            .action("nonce", nonce);
+            .action("nonce", nonce)
+            .action("tls-channel-binding", cb);
         let token = tb.sign().await.unwrap();
         let header = format!("Bearer {}", token.encode());
 
         // First use should succeed
-        auth.check_request("GET", "/sockets", &header, Some(nonce))
+        auth.check_request("GET", "/sockets", &header, Some(nonce), Some(cb))
             .expect("first use of nonce should pass");
 
         // Replay with the same nonce should fail
-        let result = auth.check_request("GET", "/sockets", &header, Some(nonce));
+        let result = auth.check_request("GET", "/sockets", &header, Some(nonce), Some(cb));
         assert!(result.is_err(), "replayed nonce should be rejected");
         assert!(
             result
@@ -1454,9 +1461,77 @@ mod sshauth_tests {
         let header = format!("Bearer {}", token.encode());
 
         // Without a nonce, the request should be rejected
-        let result = auth.check_request("GET", "/sockets", &header, None);
+        let result = auth.check_request("GET", "/sockets", &header, None, None);
         assert!(result.is_err(), "request without nonce should be rejected");
         assert!(result.unwrap_err().to_string().contains("missing nonce"));
+    }
+
+    #[tokio::test]
+    async fn test_ssh_auth_channel_binding_mismatch_rejected() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let (pubkey_line, key_path) = generate_ed25519_keypair(tmpdir.path());
+
+        let root = make_test_rootdir_with_keys(&[pubkey_line.trim()]);
+        let auth = maybe_create_ssh_authenticator(None, None, root.path())
+            .unwrap()
+            .unwrap();
+
+        let privkey_pem = std::fs::read_to_string(&key_path).unwrap();
+        let privkey = ssh_key::PrivateKey::from_openssh(&privkey_pem).unwrap();
+
+        let mut builder = sshauth::TokenSigner::using_private_key(privkey).unwrap();
+        builder.include_fingerprint(true).magic_prefix(*b"vhbridge");
+        let signer = builder.build().unwrap();
+
+        let nonce = "cb-mismatch-test12345";
+        let cb_signer = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        let cb_verifier = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
+
+        let mut tb = signer.sign_for();
+        tb.action("method", "GET")
+            .action("path", "/sockets")
+            .action("nonce", nonce)
+            .action("tls-channel-binding", cb_signer);
+        let token = tb.sign().await.unwrap();
+
+        let header = format!("Bearer {}", token.encode());
+        let result = auth.check_request("GET", "/sockets", &header, Some(nonce), Some(cb_verifier));
+        assert!(
+            result.is_err(),
+            "mismatched channel binding should be rejected (relay attack)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ssh_auth_channel_binding_match_accepted() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let (pubkey_line, key_path) = generate_ed25519_keypair(tmpdir.path());
+
+        let root = make_test_rootdir_with_keys(&[pubkey_line.trim()]);
+        let auth = maybe_create_ssh_authenticator(None, None, root.path())
+            .unwrap()
+            .unwrap();
+
+        let privkey_pem = std::fs::read_to_string(&key_path).unwrap();
+        let privkey = ssh_key::PrivateKey::from_openssh(&privkey_pem).unwrap();
+
+        let mut builder = sshauth::TokenSigner::using_private_key(privkey).unwrap();
+        builder.include_fingerprint(true).magic_prefix(*b"vhbridge");
+        let signer = builder.build().unwrap();
+
+        let nonce = "cb-match-test-123456";
+        let cb = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+        let mut tb = signer.sign_for();
+        tb.action("method", "GET")
+            .action("path", "/sockets")
+            .action("nonce", nonce)
+            .action("tls-channel-binding", cb);
+        let token = tb.sign().await.unwrap();
+
+        let header = format!("Bearer {}", token.encode());
+        auth.check_request("GET", "/sockets", &header, Some(nonce), Some(cb))
+            .expect("matching channel binding should pass");
     }
 
     #[test]
@@ -1555,5 +1630,69 @@ mod sshauth_tests {
             result.is_err(),
             "CLI path should be used, not /etc or credential"
         );
+    }
+
+    #[test_with::path(/usr/bin/varlinkctl)]
+    #[test_with::path(/run/systemd/io.systemd.Hostname)]
+    #[tokio::test]
+    async fn test_tls_ssh_e2e() {
+        let pki = make_test_pki();
+
+        let ssh_dir = tempfile::tempdir().unwrap();
+        let (pubkey_line, key_path) = generate_ed25519_keypair(ssh_dir.path());
+        let root = make_test_rootdir_with_keys(&[pubkey_line.trim()]);
+        let auth = maybe_create_ssh_authenticator(None, None, root.path())
+            .unwrap()
+            .unwrap();
+
+        let acceptor = load_tls_acceptor(
+            pki.server_cert_path.to_str().unwrap(),
+            pki.server_key_path.to_str().unwrap(),
+            None,
+        )
+        .unwrap();
+
+        let (server, local_addr) =
+            run_test_tls_server_with_auth("/run/systemd", acceptor, vec![Box::new(auth)]).await;
+        defer! {
+            server.abort();
+        };
+
+        let fake_xdg_home = tempfile::tempdir().unwrap();
+        let tls_dir = fake_xdg_home.path().join("varlink-http-bridge");
+        std::fs::create_dir_all(&tls_dir).unwrap();
+        std::fs::copy(&pki.ca_cert_path, tls_dir.join("server-ca-file")).unwrap();
+
+        let bridge_url = format!(
+            "https://localhost:{}/ws/sockets/io.systemd.Hostname",
+            local_addr.port()
+        );
+
+        let output = tokio::process::Command::new("varlinkctl")
+            .args([
+                "call",
+                "--json=short",
+                &format!("exec:{}", helper_binary().display()),
+                "io.systemd.Hostname.Describe",
+                "{}",
+            ])
+            .env("VARLINK_BRIDGE_URL", &bridge_url)
+            .env("XDG_CONFIG_HOME", fake_xdg_home.path())
+            .env("VARLINK_SSH_KEY", &key_path)
+            .output()
+            .await
+            .expect("failed to run varlinkctl");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "varlinkctl with TLS + SSH auth failed (stderr: {stderr})"
+        );
+
+        let stdout = String::from_utf8(output.stdout).expect("invalid UTF-8");
+        let line = stdout.trim().trim_start_matches('\x1e');
+        let body: serde_json::Value = serde_json::from_str(line).expect("invalid JSON");
+        let expected_hostname = gethostname().into_string().expect("failed to get hostname");
+        assert_eq!(body["Hostname"], expected_hostname);
     }
 } // mod sshauth_tests

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1061,6 +1061,34 @@ mod sshauth_tests {
         (pubkey_line, key_path)
     }
 
+    /// Set up an SSH authenticator from a freshly generated ed25519 keypair.
+    ///
+    /// Returns the authenticator plus the path to the private key (for tests
+    /// that also need to sign tokens).
+    fn make_test_ssh_auth() -> (crate::auth_ssh::SshKeyAuthenticator, std::path::PathBuf) {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let (pubkey_line, key_path) = generate_ed25519_keypair(tmpdir.path());
+        let root = make_test_rootdir_with_keys(&[pubkey_line.trim()]);
+        let auth = maybe_create_ssh_authenticator(None, None, root.path())
+            .unwrap()
+            .unwrap();
+        // Leak both tempdirs so they live for the test duration.
+        // (The keypair dir and the rootdir with authorized_keys.)
+        std::mem::forget(tmpdir);
+        std::mem::forget(root);
+        (auth, key_path)
+    }
+
+    /// Build a [`sshauth::signer::TokenSigner`] from the private key at `key_path`,
+    /// pre-configured with fingerprint and magic prefix matching the server.
+    fn make_test_token_signer(key_path: &std::path::Path) -> sshauth::signer::TokenSigner {
+        let privkey_pem = std::fs::read_to_string(key_path).unwrap();
+        let privkey = ssh_key::PrivateKey::from_openssh(&privkey_pem).unwrap();
+        let mut builder = sshauth::TokenSigner::using_private_key(privkey).unwrap();
+        builder.include_fingerprint(true).magic_prefix(*b"vhbridge");
+        builder.build().unwrap()
+    }
+
     fn make_auth_test_router(authenticators: Vec<Box<dyn Authenticator>>) -> Router {
         let tmpdir = tempfile::tempdir().unwrap();
         // Keep tmpdir so it lives for the test duration (but gets cleaned up eventually)
@@ -1070,26 +1098,7 @@ mod sshauth_tests {
 
     #[test]
     fn test_ssh_auth_parse_authorized_keys_ed25519() {
-        use openssl::pkey::PKey;
-
-        let pkey = PKey::generate_ed25519().unwrap();
-        let raw_pub = pkey.raw_public_key().unwrap();
-
-        // Build SSH blob: string "ssh-ed25519" + string <32 bytes>
-        let mut blob = Vec::new();
-        let algo = b"ssh-ed25519";
-        blob.extend_from_slice(&(algo.len() as u32).to_be_bytes());
-        blob.extend_from_slice(algo);
-        blob.extend_from_slice(&(raw_pub.len() as u32).to_be_bytes());
-        blob.extend_from_slice(&raw_pub);
-
-        let b64_blob = openssl::base64::encode_block(&blob);
-        let line = format!("ssh-ed25519 {b64_blob} testkey@host");
-        let root = make_test_rootdir_with_keys(&[&line]);
-        let auth = maybe_create_ssh_authenticator(None, None, root.path())
-            .unwrap()
-            .unwrap();
-
+        let (auth, _) = make_test_ssh_auth();
         assert_eq!(auth.key_count(), 1);
     }
 
@@ -1134,21 +1143,9 @@ mod sshauth_tests {
 
     #[tokio::test]
     async fn test_ssh_auth_rejects_expired_timestamp() {
-        let tmpdir = tempfile::tempdir().unwrap();
-        let (pubkey_line, key_path) = generate_ed25519_keypair(tmpdir.path());
-
-        let root = make_test_rootdir_with_keys(&[pubkey_line.trim()]);
-        let auth = maybe_create_ssh_authenticator(None, None, root.path())
-            .unwrap()
-            .unwrap()
-            .with_max_skew(0);
-
-        let privkey_pem = std::fs::read_to_string(&key_path).unwrap();
-        let privkey = ssh_key::PrivateKey::from_openssh(&privkey_pem).unwrap();
-
-        let mut builder = sshauth::TokenSigner::using_private_key(privkey).unwrap();
-        builder.include_fingerprint(true).magic_prefix(*b"vhbridge");
-        let signer = builder.build().unwrap();
+        let (auth, key_path) = make_test_ssh_auth();
+        let auth = auth.with_max_skew(0);
+        let signer = make_test_token_signer(&key_path);
 
         let nonce = "test-nonce-expired12345";
         let mut tb = signer.sign_for();
@@ -1168,23 +1165,12 @@ mod sshauth_tests {
     #[tokio::test]
     async fn test_ssh_auth_rejects_unknown_fingerprint() {
         // Key A: in authorized_keys
-        let tmpdir_a = tempfile::tempdir().unwrap();
-        let (pubkey_a_line, _) = generate_ed25519_keypair(tmpdir_a.path());
+        let (auth, _) = make_test_ssh_auth();
 
-        let root = make_test_rootdir_with_keys(&[pubkey_a_line.trim()]);
-        let auth = maybe_create_ssh_authenticator(None, None, root.path())
-            .unwrap()
-            .unwrap();
-
-        // Key B: NOT in authorized_keys
+        // Key B: NOT in authorized_keys — sign with this one
         let tmpdir_b = tempfile::tempdir().unwrap();
         let (_, key_path_b) = generate_ed25519_keypair(tmpdir_b.path());
-        let privkey_b_pem = std::fs::read_to_string(&key_path_b).unwrap();
-        let privkey_b = ssh_key::PrivateKey::from_openssh(&privkey_b_pem).unwrap();
-
-        let mut builder = sshauth::TokenSigner::using_private_key(privkey_b).unwrap();
-        builder.include_fingerprint(true).magic_prefix(*b"vhbridge");
-        let signer = builder.build().unwrap();
+        let signer = make_test_token_signer(&key_path_b);
 
         let nonce = "test-nonce-unknown-fp12345";
         let mut tb = signer.sign_for();
@@ -1206,20 +1192,8 @@ mod sshauth_tests {
 
     #[tokio::test]
     async fn test_ssh_auth_verify_ed25519() {
-        let tmpdir = tempfile::tempdir().unwrap();
-        let (pubkey_line, key_path) = generate_ed25519_keypair(tmpdir.path());
-
-        let root = make_test_rootdir_with_keys(&[pubkey_line.trim()]);
-        let auth = maybe_create_ssh_authenticator(None, None, root.path())
-            .unwrap()
-            .unwrap();
-
-        let privkey_pem = std::fs::read_to_string(&key_path).unwrap();
-        let privkey = ssh_key::PrivateKey::from_openssh(&privkey_pem).unwrap();
-
-        let mut builder = sshauth::TokenSigner::using_private_key(privkey).unwrap();
-        builder.include_fingerprint(true).magic_prefix(*b"vhbridge");
-        let signer = builder.build().unwrap();
+        let (auth, key_path) = make_test_ssh_auth();
+        let signer = make_test_token_signer(&key_path);
 
         let nonce = "test-nonce-verify12345";
         let cb = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
@@ -1242,23 +1216,7 @@ mod sshauth_tests {
         use axum::http::Request;
         use tower::ServiceExt;
 
-        let pkey = openssl::pkey::PKey::generate_ed25519().unwrap();
-        let raw_pub = pkey.raw_public_key().unwrap();
-
-        let mut blob = Vec::new();
-        let algo = b"ssh-ed25519";
-        blob.extend_from_slice(&(algo.len() as u32).to_be_bytes());
-        blob.extend_from_slice(algo);
-        blob.extend_from_slice(&(raw_pub.len() as u32).to_be_bytes());
-        blob.extend_from_slice(&raw_pub);
-
-        let b64_blob = openssl::base64::encode_block(&blob);
-        let line = format!("ssh-ed25519 {b64_blob} testkey@host");
-        let root = make_test_rootdir_with_keys(&[&line]);
-        let auth = maybe_create_ssh_authenticator(None, None, root.path())
-            .unwrap()
-            .unwrap();
-
+        let (auth, _) = make_test_ssh_auth();
         let app = make_auth_test_router(vec![Box::new(auth)]);
         let response = app
             .oneshot(Request::get("/sockets").body(Body::empty()).unwrap())
@@ -1273,13 +1231,7 @@ mod sshauth_tests {
         use axum::http::Request;
         use tower::ServiceExt;
 
-        let tmpdir = tempfile::tempdir().unwrap();
-        let (pubkey_line, _) = generate_ed25519_keypair(tmpdir.path());
-        let root = make_test_rootdir_with_keys(&[pubkey_line.trim()]);
-        let auth = maybe_create_ssh_authenticator(None, None, root.path())
-            .unwrap()
-            .unwrap();
-
+        let (auth, _) = make_test_ssh_auth();
         let app = make_auth_test_router(vec![Box::new(auth)]);
         let response = app
             .oneshot(
@@ -1354,23 +1306,7 @@ mod sshauth_tests {
         use axum::http::Request;
         use tower::ServiceExt;
 
-        let pkey = openssl::pkey::PKey::generate_ed25519().unwrap();
-        let raw_pub = pkey.raw_public_key().unwrap();
-
-        let mut blob = Vec::new();
-        let algo = b"ssh-ed25519";
-        blob.extend_from_slice(&(algo.len() as u32).to_be_bytes());
-        blob.extend_from_slice(algo);
-        blob.extend_from_slice(&(raw_pub.len() as u32).to_be_bytes());
-        blob.extend_from_slice(&raw_pub);
-
-        let b64_blob = openssl::base64::encode_block(&blob);
-        let line = format!("ssh-ed25519 {b64_blob} testkey@host");
-        let root = make_test_rootdir_with_keys(&[&line]);
-        let auth = maybe_create_ssh_authenticator(None, None, root.path())
-            .unwrap()
-            .unwrap();
-
+        let (auth, _) = make_test_ssh_auth();
         let app = make_auth_test_router(vec![Box::new(auth)]);
         let response = app
             .oneshot(Request::get("/health").body(Body::empty()).unwrap())
@@ -1396,20 +1332,8 @@ mod sshauth_tests {
 
     #[tokio::test]
     async fn test_ssh_auth_rejects_replayed_nonce() {
-        let tmpdir = tempfile::tempdir().unwrap();
-        let (pubkey_line, key_path) = generate_ed25519_keypair(tmpdir.path());
-
-        let root = make_test_rootdir_with_keys(&[pubkey_line.trim()]);
-        let auth = maybe_create_ssh_authenticator(None, None, root.path())
-            .unwrap()
-            .unwrap();
-
-        let privkey_pem = std::fs::read_to_string(&key_path).unwrap();
-        let privkey = ssh_key::PrivateKey::from_openssh(&privkey_pem).unwrap();
-
-        let mut builder = sshauth::TokenSigner::using_private_key(privkey).unwrap();
-        builder.include_fingerprint(true).magic_prefix(*b"vhbridge");
-        let signer = builder.build().unwrap();
+        let (auth, key_path) = make_test_ssh_auth();
+        let signer = make_test_token_signer(&key_path);
 
         let nonce = "replay-me12345678";
         let cb = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
@@ -1440,20 +1364,8 @@ mod sshauth_tests {
 
     #[tokio::test]
     async fn test_ssh_auth_rejects_missing_nonce() {
-        let tmpdir = tempfile::tempdir().unwrap();
-        let (pubkey_line, key_path) = generate_ed25519_keypair(tmpdir.path());
-
-        let root = make_test_rootdir_with_keys(&[pubkey_line.trim()]);
-        let auth = maybe_create_ssh_authenticator(None, None, root.path())
-            .unwrap()
-            .unwrap();
-
-        let privkey_pem = std::fs::read_to_string(&key_path).unwrap();
-        let privkey = ssh_key::PrivateKey::from_openssh(&privkey_pem).unwrap();
-
-        let mut builder = sshauth::TokenSigner::using_private_key(privkey).unwrap();
-        builder.include_fingerprint(true).magic_prefix(*b"vhbridge");
-        let signer = builder.build().unwrap();
+        let (auth, key_path) = make_test_ssh_auth();
+        let signer = make_test_token_signer(&key_path);
 
         let mut tb = signer.sign_for();
         tb.action("method", "GET").action("path", "/sockets");
@@ -1468,20 +1380,8 @@ mod sshauth_tests {
 
     #[tokio::test]
     async fn test_ssh_auth_channel_binding_mismatch_rejected() {
-        let tmpdir = tempfile::tempdir().unwrap();
-        let (pubkey_line, key_path) = generate_ed25519_keypair(tmpdir.path());
-
-        let root = make_test_rootdir_with_keys(&[pubkey_line.trim()]);
-        let auth = maybe_create_ssh_authenticator(None, None, root.path())
-            .unwrap()
-            .unwrap();
-
-        let privkey_pem = std::fs::read_to_string(&key_path).unwrap();
-        let privkey = ssh_key::PrivateKey::from_openssh(&privkey_pem).unwrap();
-
-        let mut builder = sshauth::TokenSigner::using_private_key(privkey).unwrap();
-        builder.include_fingerprint(true).magic_prefix(*b"vhbridge");
-        let signer = builder.build().unwrap();
+        let (auth, key_path) = make_test_ssh_auth();
+        let signer = make_test_token_signer(&key_path);
 
         let nonce = "cb-mismatch-test12345";
         let cb_signer = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
@@ -1504,20 +1404,8 @@ mod sshauth_tests {
 
     #[tokio::test]
     async fn test_ssh_auth_channel_binding_match_accepted() {
-        let tmpdir = tempfile::tempdir().unwrap();
-        let (pubkey_line, key_path) = generate_ed25519_keypair(tmpdir.path());
-
-        let root = make_test_rootdir_with_keys(&[pubkey_line.trim()]);
-        let auth = maybe_create_ssh_authenticator(None, None, root.path())
-            .unwrap()
-            .unwrap();
-
-        let privkey_pem = std::fs::read_to_string(&key_path).unwrap();
-        let privkey = ssh_key::PrivateKey::from_openssh(&privkey_pem).unwrap();
-
-        let mut builder = sshauth::TokenSigner::using_private_key(privkey).unwrap();
-        builder.include_fingerprint(true).magic_prefix(*b"vhbridge");
-        let signer = builder.build().unwrap();
+        let (auth, key_path) = make_test_ssh_auth();
+        let signer = make_test_token_signer(&key_path);
 
         let nonce = "cb-match-test-123456";
         let cb = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
@@ -1637,13 +1525,7 @@ mod sshauth_tests {
     #[tokio::test]
     async fn test_tls_ssh_e2e() {
         let pki = make_test_pki();
-
-        let ssh_dir = tempfile::tempdir().unwrap();
-        let (pubkey_line, key_path) = generate_ed25519_keypair(ssh_dir.path());
-        let root = make_test_rootdir_with_keys(&[pubkey_line.trim()]);
-        let auth = maybe_create_ssh_authenticator(None, None, root.path())
-            .unwrap()
-            .unwrap();
+        let (auth, key_path) = make_test_ssh_auth();
 
         let acceptor = load_tls_acceptor(
             pki.server_cert_path.to_str().unwrap(),


### PR DESCRIPTION
This commit adds tls channel binding for the sshauth authentication.
We only support the mechanism described in rfc9266 which implies that
we will only support TLS1.3. This should be fine as we control both
the client and server side.

Thanks to bjorn3 for reporting this!

Closes: https://github.com/mvo5/varlink-http-bridge/issues/17
